### PR TITLE
Update gulpfile.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slush-luxe",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Slush generator for the luxe engine (HaXe)",
   "main": "slushfile.js",
   "scripts": {

--- a/templates/gulp/gulpfile.js
+++ b/templates/gulp/gulpfile.js
@@ -13,7 +13,7 @@ gulp.task('haxe:watch', ['haxe:build'], function(done){
   done();
 })
 
-gulp.task('watch',  function(done){
+gulp.task('watch', ['haxe:build'], function(done){
   browserSync.init({
     server: {
       baseDir: './bin/web'
@@ -23,7 +23,7 @@ gulp.task('watch',  function(done){
   gulp.watch(['src/**', 'assets/**'], ['haxe:watch']);
 });
 
-gulp.task('default', ['haxe:build', 'watch']);
+gulp.task('default', ['watch']);
 
 gulp.task('deploy', ['haxe:build'], function (done) {
   gh.publish(path.join(__dirname, 'bin/web'));


### PR DESCRIPTION
when `watch` task is ran for the first time, `bin/web` doesn't exist, so you have to manually reload the page 
